### PR TITLE
wss.aplc logs go through EWC logs, timeout is more defensive

### DIFF
--- a/EWC/onTimeout.aplf
+++ b/EWC/onTimeout.aplf
@@ -1,6 +1,11 @@
 r←onTimeout args;m;conns
-
-:If 2=⎕NC 'WSS.Conx'
-:AndIf ∨/m←~WSS.LDRC.Exists¨conns←WSS.Conx[;1]
-    endSession¨{0 ⍵ 'Close'}¨m/conns
-:EndIf
+⍝ Admittedly slightly over-defensive Trap
+ :Trap 0
+     :If 9=⎕NC 'WSS'
+     :AndIf 0≠≢conns←WSS.Conx[;1]
+     :AndIf ∨/m←~WSS.LDRC.Exists¨conns
+         endSession¨{0 ⍵ 'Close'}¨m/conns
+     :EndIf
+ :Else
+     'E' Log 'onTimeout failed: ',⊃⎕DMX.DM
+ :EndTrap

--- a/EWC/wss.aplc
+++ b/EWC/wss.aplc
@@ -378,8 +378,12 @@
     ∇
 
 
-    ∇ Log msg
-      ⎕←msg
+    ∇ {mode} Log msg
+     ⍝ Small HACK to route through EWC.Log
+     ⍝ If we want to set EWC.LOGFILE to redirect logs, we also want WebSocket
+     ⍝ related messages to go there.
+      :If 0=⎕NC'mode' ⋄ mode←'C' ⋄ :EndIf
+      :Trap 0 ⋄ mode #.EWC.Log msg ⋄ :Else ⋄ ⎕←mode,': ',msg ⋄ :EndTrap
     ∇
 
     dlb←{⍵↓⍨+/∧\' '=⍵}


### PR DESCRIPTION
Timeout wasn't firing in testing, so minor changes were made, and it is also now more defensive with the :Trap (we suspected there was an issue here, so made it an error log instead)